### PR TITLE
Rw add remaining activity functionality

### DIFF
--- a/src/Activity-repo.js
+++ b/src/Activity-repo.js
@@ -66,7 +66,6 @@ class ActivityRepo extends DataRepo {
     let sortedData = this.sortDataByDate(userData);
     let indexOfDate = this.getIndexOfDate(date, sortedData)
     let weekOfData = this.getDataInDateSpan(indexOfDate, 7, sortedData);
-    console.log(weekOfData)
     return weekOfData;
   }
 
@@ -100,12 +99,11 @@ class ActivityRepo extends DataRepo {
     return [sortedData[0].name, sortedData[0].userSum, sortedData[0].id]
   }
 
-////NEEDS REFACTORING 
-  getIncreasinglyActiveDates(id, date, dataKey) {
+  getIncreasinglyActiveDates(id, date) {
     let weekOfData = this.getUserDataForWeek(id, date).reverse(); 
     let increasinglyActiveDates = []
     weekOfData.reduce((previousData, currentData) => {
-      if (currentData[dataKey] > previousData[dataKey]) {
+      if (currentData.minutesActive > previousData.minutesActive) {
         increasinglyActiveDates.push(currentData.date)
       }
       previousData = currentData;
@@ -114,20 +112,18 @@ class ActivityRepo extends DataRepo {
     return increasinglyActiveDates; 
   }
 
-
-  // displayIncreasedSteps(userRepo, id, dataKey) {
-  //   let data = this.activityData;
-  //   let sortedUserArray = (userRepo.sortDataByDate(id, data)).reverse();
-  //   let streaks = sortedUserArray.filter(function(element, index) {
-  //     if (index >= 2) {
-  //       return (sortedUserArray[index - 2][dataKey] < sortedUserArray[index - 1][dataKey] && sortedUserArray[index - 1][dataKey] < sortedUserArray[index][dataKey])
-  //     }
-  //   });
-  //   return streaks.map(function(streak) {
-  //     return streak.date;
-  //   })
-  // }
-
+  getThreeDayStepStreaks(id, date) {
+    let userData = this.getDataMatchingUserID(id, this.activityData);
+    let sortedData = this.sortDataByDate(userData);
+    let indexOfDate = this.getIndexOfDate(date, sortedData);
+    let monthOfData = this.getDataInDateSpan(indexOfDate, 30, sortedData).reverse();
+    return monthOfData.reduce((streakDays, currentDay, i, month) => {
+      if (i >= 2 && currentDay.numSteps > month[i - 1].numSteps && month[i - 1].numSteps > month[i - 2].numSteps) {
+        streakDays.push(currentDay.date);
+      }
+      return streakDays; 
+    }, []);
+  }
 }
 
 

--- a/src/Activity-repo.js
+++ b/src/Activity-repo.js
@@ -66,6 +66,7 @@ class ActivityRepo extends DataRepo {
     let sortedData = this.sortDataByDate(userData);
     let indexOfDate = this.getIndexOfDate(date, sortedData)
     let weekOfData = this.getDataInDateSpan(indexOfDate, 7, sortedData);
+    console.log(weekOfData)
     return weekOfData;
   }
 
@@ -99,18 +100,33 @@ class ActivityRepo extends DataRepo {
     return [sortedData[0].name, sortedData[0].userSum, sortedData[0].id]
   }
 
-  displayIncreasedSteps(userRepo, id, dataKey) {
-    let data = this.activityData;
-    let sortedUserArray = (userRepo.sortDataByDate(id, data)).reverse();
-    let streaks = sortedUserArray.filter(function(element, index) {
-      if (index >= 2) {
-        return (sortedUserArray[index - 2][dataKey] < sortedUserArray[index - 1][dataKey] && sortedUserArray[index - 1][dataKey] < sortedUserArray[index][dataKey])
+////NEEDS REFACTORING 
+  getIncreasinglyActiveDates(id, date, dataKey) {
+    let weekOfData = this.getUserDataForWeek(id, date).reverse(); 
+    let increasinglyActiveDates = []
+    weekOfData.reduce((previousData, currentData) => {
+      if (currentData[dataKey] > previousData[dataKey]) {
+        increasinglyActiveDates.push(currentData.date)
       }
-    });
-    return streaks.map(function(streak) {
-      return streak.date;
-    })
+      previousData = currentData;
+      return previousData;  
+    }); 
+    return increasinglyActiveDates; 
   }
+
+
+  // displayIncreasedSteps(userRepo, id, dataKey) {
+  //   let data = this.activityData;
+  //   let sortedUserArray = (userRepo.sortDataByDate(id, data)).reverse();
+  //   let streaks = sortedUserArray.filter(function(element, index) {
+  //     if (index >= 2) {
+  //       return (sortedUserArray[index - 2][dataKey] < sortedUserArray[index - 1][dataKey] && sortedUserArray[index - 1][dataKey] < sortedUserArray[index][dataKey])
+  //     }
+  //   });
+  //   return streaks.map(function(streak) {
+  //     return streak.date;
+  //   })
+  // }
 
 }
 

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -193,23 +193,17 @@ const domUpdates = {
     return friendActivityData.map(friendChallengeData => `<li class="historical-list-listItem">Your friend ${friendChallengeData.name}, averaged ${friendChallengeData.userSum} steps.</li>`).join('');
   },
 
-  //NEW
+  createStepStreak(activeDates) {
+    return activeDates.map(date => `<li class="historical-list-listItem">${date}</li>`).join('');
+  },
 
+  addIncreasinglyActiveInfo() {
+    let increasedActivityStreak = document.getElementById('streakListMinutes')
+    increasedActivityStreak.insertAdjacentHTML("afterBegin", this.createStepStreak(this.activityRepo.getIncreasinglyActiveDates(this.user.id, this.today)));
 
- createStepStreak(activeDates) {
-  return activeDates.map(date => `<li class="historical-list-listItem">${date}</li>`).join('');
-},
-
-addIncreasinglyActiveInfo() {
-  let increasedActivityStreak = document.getElementById('streakListMinutes')
-  increasedActivityStreak.insertAdjacentHTML("afterBegin", this.createStepStreak(this.activityRepo.getIncreasinglyActiveDates(this.user.id, this.today, 'minutesActive')));
-
-  // let stepStreak = document.getElementById('streakList');
-  // stepStreak.insertAdjacentHTML("afterBegin", createStepStreak(userNow.id, activityRepo, userRepo, activityRepo.displayIncreasedSteps(userRepo, userNow.id, 'numSteps')));
-} 
-
-
-
+    let stepStreak = document.getElementById('streakList');
+    stepStreak.insertAdjacentHTML("afterBegin", this.createStepStreak(this.activityRepo.getThreeDayStepStreaks(this.user.id, this.today)))
+  } 
 }
 
 module.exports = domUpdates

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -191,7 +191,22 @@ const domUpdates = {
 
   makeFriendChallengeHTML(friendActivityData) {
     return friendActivityData.map(friendChallengeData => `<li class="historical-list-listItem">Your friend ${friendChallengeData.name}, averaged ${friendChallengeData.userSum} steps.</li>`).join('');
-  }
+  },
+
+  //NEW
+
+
+ createStepStreak(activeDates) {
+  return activeDates.map(date => `<li class="historical-list-listItem">${date}</li>`).join('');
+},
+
+addIncreasinglyActiveInfo() {
+  let increasedActivityStreak = document.getElementById('streakListMinutes')
+  increasedActivityStreak.insertAdjacentHTML("afterBegin", this.createStepStreak(this.activityRepo.getIncreasinglyActiveDates(this.user.id, this.today, 'minutesActive')));
+
+  // let stepStreak = document.getElementById('streakList');
+  // stepStreak.insertAdjacentHTML("afterBegin", createStepStreak(userNow.id, activityRepo, userRepo, activityRepo.displayIncreasedSteps(userRepo, userNow.id, 'numSteps')));
+} 
 
 
 

--- a/src/index.html
+++ b/src/index.html
@@ -35,7 +35,7 @@
                 </ul>
               </section>
               <section class="sidebar-header-line"></section>
-              <p class="thisWeek">Keep up the good work! You were increasingly active on these dates:</p>
+              <p class="thisWeek">Keep up the good work! You were increasingly active on these dates this week:</p>
               <ul class="card-vertical-list" id="streakListMinutes">
                 <!-- friend list goes here -->
               </ul>
@@ -191,7 +191,7 @@
                 </ul>
                 <section class="sidebar-header-line"></section>
               </section>
-              <p class="thisWeek">You had 3 DAY STEP STREAKS on these days:</p>
+              <p class="thisWeek">You had 3-day step streaks on these days over the past 30 days:</p>
               <ul class="card-vertical-list" id="streakList">
                 <!-- friend list goes here -->
               </ul>

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -210,21 +210,6 @@ function addFriendGameInfo() {
   domUpdates.displayFriendChallenge();
 }
 
-//These currently need to be refactored in Activity Repo! Then, we'll need to hook these back up to our display methods here.
-
-// function createStepStreak(activeDates) {
-//   return activeDates.map(streakData => `<li class="historical-list-listItem">${streakData}!</li>`).join('');
-// };
-
-// function addIncreasinglyActiveInfo(id, dateString, activityInfo, userStorage, laterDateString, user) {
-//   let increasedActivityStreak = document.getElementById('streakListMinutes')
-//   increasedActivityStreak.insertAdjacentHTML("afterBegin", createStepStreak(activityRepo.getIncreasinglyActiveDates(id, dateString, 'minutesActive')));
-  
-//   // let stepStreak = document.getElementById('streakList');
-//   // stepStreak.insertAdjacentHTML("afterBegin", createStepStreak(userNow.id, activityRepo, userRepo, activityRepo.displayIncreasedSteps(userRepo, userNow.id, 'numSteps')));
-// } 
-
-
 /*---------Display View Functions---------*/
 function accessSleepInputForm() {
   mainPage.classList.add('hidden')

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -126,8 +126,8 @@ function createDataRepos(userData, sleepData, activityData, hydrationData) {
 function createUser() {
   let userNowId = generateRandomId(userRepo);
   userNow = generateRandomUser(userRepo, userNowId);
-  today = makeToday(userRepo, userNowId, hydrationRepo.hydrationData);
-  // today = '2020/01/22';
+  // today = makeToday(userRepo, userNowId, hydrationRepo.hydrationData);
+  today = '2020/01/22';
   randomHistory = hydrationRepo.makeRandomDate(hydrationRepo.hydrationData);
   domUpdates.defineUser(userNow);
   domUpdates.defineToday(today);
@@ -200,6 +200,7 @@ function addActivityInfo() {
   domUpdates.displayDailyActivity();
   domUpdates.displayAverageDailyActivity();
   domUpdates.displayWeeklyActivity();
+  domUpdates.addIncreasinglyActiveInfo();
 }
 
 
@@ -210,15 +211,18 @@ function addFriendGameInfo() {
 }
 
 //These currently need to be refactored in Activity Repo! Then, we'll need to hook these back up to our display methods here.
-  // let increasedActivityStreak = document.getElementById('streakListMinutes')
-  // increasedActivityStreak.insertAdjacentHTML("afterBegin", createStepStreak(userNow.id, activityRepo, userRepo, activityRepo.displayIncreasedSteps(userRepo, userNow.id, 'minutesActive')));
-  //
-  // let stepStreak = document.getElementById('streakList');
-  // stepStreak.insertAdjacentHTML("afterBegin", createStepStreak(userNow.id, activityRepo, userRepo, activityRepo.displayIncreasedSteps(userRepo, userNow.id, 'numSteps')));
 
-  // function createStepStreak(id, activityInfo, userStorage, method) {
-//   return method.map(streakData => `<li class="historical-list-listItem">${streakData}!</li>`).join('');
-// }
+// function createStepStreak(activeDates) {
+//   return activeDates.map(streakData => `<li class="historical-list-listItem">${streakData}!</li>`).join('');
+// };
+
+// function addIncreasinglyActiveInfo(id, dateString, activityInfo, userStorage, laterDateString, user) {
+//   let increasedActivityStreak = document.getElementById('streakListMinutes')
+//   increasedActivityStreak.insertAdjacentHTML("afterBegin", createStepStreak(activityRepo.getIncreasinglyActiveDates(id, dateString, 'minutesActive')));
+  
+//   // let stepStreak = document.getElementById('streakList');
+//   // stepStreak.insertAdjacentHTML("afterBegin", createStepStreak(userNow.id, activityRepo, userRepo, activityRepo.displayIncreasedSteps(userRepo, userNow.id, 'numSteps')));
+// } 
 
 
 /*---------Display View Functions---------*/

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -82,7 +82,7 @@ function createHydrationBody() {
 }
 
 function createActivityBody() {
-  let userActivityDate = document.getElementById('acitivity-user-date').value
+  let userActivityDate = document.getElementById('activity-user-date').value
   let userNumberOfSteps = parseFloat(document.getElementById('user-step-number').value)
   let userMinutesActive = parseFloat(document.getElementById('user-minutes-active').value)
   let userStairsClimbed = parseFloat(document.getElementById('user-stairs-climbed').value)

--- a/test/activity-repo-test.js
+++ b/test/activity-repo-test.js
@@ -82,7 +82,7 @@ describe('Activity', function() {
       {
         "userID": 2,
         "date": "2019/06/12",
-        "numSteps": 4000,
+        "numSteps": 6000,
         "minutesActive": 120,
         "flightsOfStairs": 10
       },
@@ -96,7 +96,7 @@ describe('Activity', function() {
       {
         "userID": 2,
         "date": "2019/06/10",
-        "numSteps": 4000,
+        "numSteps": 2000,
         "minutesActive": 120,
         "flightsOfStairs": 10
       },
@@ -261,13 +261,13 @@ describe('Activity', function() {
   it('should return all days that a given user exceeded their step goal', function() {
     expect(activityRepo.exceededStepGoalForDay(1, userRepo)).to.deep.equal(
       [
-      '2019/06/15',
-      "2019/06/14",
-      "2019/06/13",
-      "2019/06/12",
-      "2019/06/11",
-      "2019/06/10",
-      "2019/06/09"
+        '2019/06/15',
+        "2019/06/14",
+        "2019/06/13",
+        "2019/06/12",
+        "2019/06/11",
+        "2019/06/10",
+        "2019/06/09"
       ]
     );
   });
@@ -313,7 +313,7 @@ describe('Activity', function() {
         {
           id: 2,
           name: "Allie McCarthy",
-          userData: [4000, 4000, 4000, 4000, 4000, 4000, 4000],
+          userData: [4000, 4000, 4000, 6000, 4000, 2000, 4000],
           userSum: 28000
         },
         {
@@ -330,17 +330,15 @@ describe('Activity', function() {
     expect(activityRepo.getStepChallengeWinner(userRepo.users[0], "2019/06/15", userRepo)[0]).to.equal('Alex Roth')
   })
 
-  it.only('should know the ID of the winning friend', function() {
+  it('should know the ID of the winning friend', function() {
     expect(activityRepo.getStepChallengeWinner(userRepo.users[0], '2019/06/15', userRepo)[2]).to.equal(1)
   });
 
-  //THIS SECTION HAS NOT BEEN EDITED YET
-
-  it('should show a 3-day increasing streak for a users step count', function() {
-    expect(activityRepo.displayIncreasedSteps(userRepo, 11, 'numSteps')).to.deep.equal(['2019/06/17'])
+  it('should show be able to calculate the days over a week that a user was increasingly active', function() {
+    expect(activityRepo.getIncreasinglyActiveDates(11, '2019/06/17')).to.deep.equal(['2019/06/16', '2019/06/17'])
   });
 
   it('should show a 3-day increasing streak for a users minutes of activity', function() {
-    expect(activityRepo.displayIncreasedSteps(userRepo, 11, 'minutesActive')).to.equal(['2019/06/17'])
+    expect(activityRepo.getThreeDayStepStreaks(2, '2019/06/15')).to.deep.equal(['2019/06/12'])
   });
 });


### PR DESCRIPTION
### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling- no new features

### Detailed Description
- This adds back activityRepo methods to calculate both the current user's increasingly active dates over the past week & the dates over the past 30 days where they had a 3-day streak of increased step counts. 
- Display functions were also edited and added back to the DOM object to enable these dates to display
- ActivityRepo tests were edited accordingly

### Why is this change required? What problem does it solve?
This means that all 3 bullet points of iteration 5 are now complete (when only 1 was required). 

### Were there any challenges that arose while implementing this feature? If so, how were the addressed?
Nothing significant

### Files modified:
- Activity-repo.js
- domUpdates.js
- scripts.js 
- index.html
- activity-repo-test.js 

### Relevant tickets:
#57 & #58 

